### PR TITLE
Add Gulp tasks to copy images and fonts [closes #12]

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,15 +5,17 @@
     var browserSync = require('browser-sync');
     var reload = browserSync.reload;
 
-    gulp.task('compile:styles', compileStyles);
-    gulp.task('compile:scripts', compileScripts);
-    gulp.task('build', ['compile:scripts', 'compile:styles'], function(){});
+    gulp.task('styles', styles);
+    gulp.task('scripts', scripts);
+    gulp.task('fonts', fonts);
+    gulp.task('images', images);
+    gulp.task('build', ['scripts', 'styles', 'fonts', 'images'], function(){});
     gulp.task('serve', ['build'], serve);
     gulp.task('default', ['serve'], function (){});
 
   // Styles ------------------------------------------------------------
 
-  function compileStyles() {
+  function styles() {
     var sass = require('gulp-sass');
     var autoprefixer = require('gulp-autoprefixer');
 
@@ -31,11 +33,27 @@
 
   // Scripts -----------------------------------------------------------
 
-	function compileScripts() {
+	function scripts() {
     return gulp.src('app/scripts/**/*.js')
       .pipe(concat('app.js'))
       .pipe(gulp.dest('dist/scripts/'))
       .pipe(reload({stream: true}));
+  }
+
+  // Fonts -----------------------------------------------------------
+
+  function fonts() {
+    return gulp.src('app/assets/fonts/**/*')
+    .pipe(gulp.dest('dist/assets/fonts'))
+    .pipe(reload({stream: true}));
+  }
+
+  // Images -----------------------------------------------------------
+
+  function images() {
+    return gulp.src('app/assets/images/**/*')
+    .pipe(gulp.dest('dist/assets/images'))
+    .pipe(reload({stream: true}));
   }
 
   // Serve ------------------------------------------------------------
@@ -55,8 +73,10 @@
       'app/scripts/**/*.js'
     ]).on('change', reload);
 
-    gulp.watch('app/stylesheets/**/*.scss', ['compile:styles']);
-    gulp.watch('app/scripts/**/*.js', ['compile:scripts']);
+    gulp.watch('app/stylesheets/**/*.scss', ['styles']);
+    gulp.watch('app/scripts/**/*.js', ['scripts']);
+    gulp.watch('app/assets/fonts/**/*', ['fonts']);
+    gulp.watch('app/assets/images/**/*', ['images']);
   }
 
 })(require);


### PR DESCRIPTION
- Current paths for assets files in SASS need to be appended with `../..` due to assets not being in the generated /dist directory that the main.css file is served from.  Example: `background: url(../../app/assets/images/background.jpg)`
- Assets in the app/assets/ directories will now be copied to the corresponding directories in dist/ so they can be referenced like this: `background: url(../assets/images/background.jpg)`

Image optimization/compression may be added next.

:eyes: @Wimsy113 @Scripore Please review
