### PR TITLE
Change <img> tag to Rails helper `image_tag` to work w/ asset pipeline

### DIFF
--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -1,10 +1,10 @@
 <div class="landing-page__container">
   <header class="landing-page__header">
-    <h1>We are one because we <img class="landing-page__logo" src="assets/srvd-final.png" alt="SRVD logo"> .</h1>
+    <h1>We are one because we <%= image_tag("srvd-final.png", class: "landing-page__logo", alt: "SRVD logo") %> .</h1>
   </header>
   <header class="landing-page__header--mobile">
     <h1>We are one because we</h1>
-    <%= image_tag("images/srvd-final.png", class: "landing-page__logo--mobile", alt: "SRVD logo") %>
+    <%= image_tag("srvd-final.png", class: "landing-page__logo--mobile", alt: "SRVD logo") %>
   </header>
   <section class="contact-box">
         <h2>pardon our dust</h2>

--- a/app/views/landing_page/index.html.erb
+++ b/app/views/landing_page/index.html.erb
@@ -4,7 +4,7 @@
   </header>
   <header class="landing-page__header--mobile">
     <h1>We are one because we</h1>
-    <img class="landing-page__logo--mobile" src="assets/srvd-final.png" alt="SRVD logo">
+    <%= image_tag("images/srvd-final.png", class: "landing-page__logo--mobile", alt: "SRVD logo") %>
   </header>
   <section class="contact-box">
         <h2>pardon our dust</h2>


### PR DESCRIPTION
Aiming to solve issue of SRVD icon image on landing page not linking to cache-buster URL served by Rails asset pipeline.
